### PR TITLE
add dependency on ccloader v2.21.0

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -26,6 +26,7 @@
 	"dependencies": {
 		"extendable-severed-heads": "^1.0.0",
 		"crosscode": ">=1.4.0",
+		"ccloader": "^2.21.0",
 		"post-game": ">=1.4.0"
 	}
 }


### PR DESCRIPTION
Your use of extension dependencies (specifically `post-game`) is only supported by versions of CCLoader after 2.21.0. However, your mod manifest only includes a requirement on `post-game`. Versions of CCLoader prior to 2.21.0 lack any support for extension dependencies, and as such will fail to load the mod (unless they conveniently have a mod with the id of `post-game`). An example of a user running into this issue can be found [here](https://discord.com/channels/382339402338402315/382339402338402317/1010733020963147856) in the CrossCode Modding discord. 

While 2.21.0 is not the latest version of CCLoader (at the point of writing this, the current version is 2.22.1) you do not use any features added in newer versions which justify a higher minimum version. 